### PR TITLE
[add] Fdroid badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
 
             <div class="center-align">
                 <a href='https://play.google.com/store/apps/details?id=ch.deletescape.lawnchair.plah&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' target="_blank" class="responsive-img" style="height: 100px;" /></a>
+                <a href="https://f-droid.org/packages/ch.deletescape.lawnchair.plah/" target="_blank"><img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" target="_blank" class="responsive-img" style="height: 100px;" /></a>
             </div>
         </div>
 


### PR DESCRIPTION
Problem : 
- Some users uses fdroid (most of users who use free softwares) and they don't see it on the main page.

Solution : 
- Add the fdroid badge (from the README) on the main website page.

Status : 
- Tested. 