### PR TITLE
chore: Update sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -29,7 +29,7 @@
 </url>
 <url>
   <loc>https://lawnchair.app/blog/lawnstate-2025-reflection/</loc>
-  <lastmod>2026-01-08</lastmod>
+  <lastmod>2025-12-30</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
@@ -59,7 +59,7 @@
 </url>
 <url>
   <loc>https://lawnchair.app/lawnicons-dashboard/</loc>
-  <lastmod>2026-01-08</lastmod>
+  <lastmod>2025-12-30</lastmod>
   <priority>0.50</priority>
 </url>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -9,17 +9,17 @@
 
 <url>
   <loc>https://lawnchair.app/</loc>
-  <lastmod>2025-08-22T03:40:31+00:00</lastmod>
+  <lastmod>2025-12-25</lastmod>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://lawnchair.app/blog/</loc>
-  <lastmod>2025-08-22T03:40:31+00:00</lastmod>
+  <lastmod>2026-01-08</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://lawnchair.app/downloads/</loc>
-  <lastmod>2025-08-22T03:40:31+00:00</lastmod>
+  <lastmod>2025-12-25</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
@@ -30,7 +30,12 @@
 <url>
   <loc>https://lawnchair.app/privacy_policy/</loc>
   <lastmod>2025-08-22T03:40:31+00:00</lastmod>
-  <priority>0.80</priority>
+  <priority>0.40</priority>
+</url>
+<url>
+  <loc>https://lawnchair.app/blog/lawnstate-2025-reflection/</loc>
+  <lastmod>2026-01-08</lastmod>
+  <priority>0.64</priority>
 </url>
 <url>
   <loc>https://lawnchair.app/blog/lawnstate-building-momentum/</loc>
@@ -45,12 +50,22 @@
 <url>
   <loc>https://lawnchair.app/blog/lawnchair-14/</loc>
   <lastmod>2025-08-22T03:40:31+00:00</lastmod>
-  <priority>0.64</priority>
+  <priority>0.35</priority>
 </url>
 <url>
   <loc>https://lawnchair.app/faq/</loc>
   <lastmod>2025-08-22T03:40:31+00:00</lastmod>
   <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://lawnchair.app/privacy-policy/</loc>
+  <lastmod>2025-08-22T03:40:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://lawnchair.app/lawnicons-dashboard/</loc>
+  <lastmod>2026-01-08</lastmod>
+  <priority>0.50</priority>
 </url>
 
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -28,11 +28,6 @@
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://lawnchair.app/privacy_policy/</loc>
-  <lastmod>2025-08-22T03:40:31+00:00</lastmod>
-  <priority>0.40</priority>
-</url>
-<url>
   <loc>https://lawnchair.app/blog/lawnstate-2025-reflection/</loc>
   <lastmod>2026-01-08</lastmod>
   <priority>0.64</priority>
@@ -43,7 +38,7 @@
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://lawnchair.app/blog/lawnchair-15-beta-1/index.html</loc>
+  <loc>https://lawnchair.app/blog/lawnchair-15-beta-1</loc>
   <lastmod>2025-08-22T03:40:31+00:00</lastmod>
   <priority>0.64</priority>
 </url>
@@ -60,7 +55,7 @@
 <url>
   <loc>https://lawnchair.app/privacy-policy/</loc>
   <lastmod>2025-08-22T03:40:31+00:00</lastmod>
-  <priority>0.64</priority>
+  <priority>0.40</priority>
 </url>
 <url>
   <loc>https://lawnchair.app/lawnicons-dashboard/</loc>


### PR DESCRIPTION
Add latest Lawnstate blog, update last modified date, remove redirection to privacy policy, deprioritised privacy policy and older blogs like Lawnchair 14

This change benefit Google SEO, and other engine SEO but I'll note that Google SEO does not account value like `priority` and `changefreq` but `lastmod` if it's consistently correct.