### PR TITLE
Add workflow to auto-update icon requests status based on Lawnicons major releases

### DIFF
--- a/.github/workflows/update_icon_requests_status.yaml
+++ b/.github/workflows/update_icon_requests_status.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           ENABLED=${{ steps.check.outputs.enabled }}
           echo "Setting enabled=$ENABLED"
-          echo "{\"enabled\": $ENABLED}" > lawnicons-request/settings.json
+          jq --argjson e "$ENABLED" '.enabled = $e' lawnicons-request/settings.json > tmp.json && mv tmp.json lawnicons-request/settings.json
 
       - name: Commit changes
         run: |

--- a/.github/workflows/update_icon_requests_status.yaml
+++ b/.github/workflows/update_icon_requests_status.yaml
@@ -1,0 +1,57 @@
+name: Update Icon Requests Status
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check latest major release
+        id: check
+        run: |
+          RELEASES=$(curl -s https://api.github.com/repos/LawnchairLauncher/lawnicons/releases?per_page=20)
+          LATEST_MAJOR=$(echo "$RELEASES" | jq -r '[.[] | select(.tag_name | test("^[0-9]+\\.[0-9]+\\.0$"))] | .[0]')
+          
+          if [ "$LATEST_MAJOR" = "null" ]; then
+            echo "No major release found"
+            echo "days_since=999" >> $GITHUB_OUTPUT
+            echo "enabled=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          PUBLISHED=$(echo "$LATEST_MAJOR" | jq -r '.published_at')
+          TAG=$(echo "$LATEST_MAJOR" | jq -r '.tag_name')
+          echo "Latest major release: $TAG ($PUBLISHED)"
+          
+          RELEASE_DATE=$(date -d "$PUBLISHED" +%s)
+          NOW=$(date +%s)
+          DAYS=$(( (NOW - RELEASE_DATE) / 86400 ))
+          echo "Days since release: $DAYS"
+          echo "days_since=$DAYS" >> $GITHUB_OUTPUT
+          
+          if [ "$DAYS" -le 14 ]; then
+            echo "enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "enabled=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update settings.json
+        run: |
+          ENABLED=${{ steps.check.outputs.enabled }}
+          echo "Setting enabled=$ENABLED"
+          echo "{\"enabled\": $ENABLED}" > lawnicons-request/settings.json
+
+      - name: Commit changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add .
+          git diff --quiet && git diff --staged --quiet || (git commit -m "Update requests status: enabled=$ENABLED" && git push)

--- a/.github/workflows/update_icon_requests_status.yaml
+++ b/.github/workflows/update_icon_requests_status.yaml
@@ -46,9 +46,22 @@ jobs:
       - name: Update settings.json
         run: |
           ENABLED=${{ steps.check.outputs.enabled }}
-          echo "Setting enabled=$ENABLED"
-          jq --argjson e "$ENABLED" '.enabled = $e' lawnicons-request/settings.json > tmp.json && mv tmp.json lawnicons-request/settings.json
-
+          PREV_ENABLED=$(jq -r '.enabled' lawnicons-request/settings.json)
+          
+          if [ "$ENABLED" = "true" ]; then
+            jq --argjson e "$ENABLED" '.enabled = $e' lawnicons-request/settings.json > tmp.json && mv tmp.json lawnicons-request/settings.json
+          else
+            FETCH_AFTER=$(jq -r '.fetch_emails_after // ""' lawnicons-request/settings.json)
+            if [ "$PREV_ENABLED" = "true" ] && [ -z "$FETCH_AFTER" ]; then
+              TODAY=$(date +%Y-%m-%d)
+              jq --argjson e "$ENABLED" --arg f "$TODAY" \
+                '.enabled = $e | .fetch_emails_after = $f' \
+                lawnicons-request/settings.json > tmp.json && mv tmp.json lawnicons-request/settings.json
+            else
+              jq --argjson e "$ENABLED" '.enabled = $e' lawnicons-request/settings.json > tmp.json && mv tmp.json lawnicons-request/settings.json
+            fi
+          fi
+          
       - name: Commit changes
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/lawnicons-request/settings.json
+++ b/lawnicons-request/settings.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Managed by update_icon_requests_status workflow. When enabled: requests are open. When disabled with fetch_emails_after set: emails collected once. See https://github.com/LawnchairLauncher/lawnicons-requests-dashboard/blob/main/scripts/fetch_emails.py",
+  "_comment": "Managed by update_icon_requests_status workflow. When enabled: requests are open. When disabled with fetch_emails_after set: emails collected twice. See https://github.com/LawnchairLauncher/lawnicons-requests-dashboard/blob/main/scripts/fetch_emails.py",
   "enabled": false,
   "fetch_emails_after": null
 }

--- a/lawnicons-request/settings.json
+++ b/lawnicons-request/settings.json
@@ -1,4 +1,5 @@
 {
-  "__comment": "When true, fetch_emails.py in lawnicons-requests-dashboard will collect icon request emails from Gmail. See https://github.com/LawnchairLauncher/lawnicons-requests-dashboard/blob/main/scripts/fetch_emails.py",
-  "enabled": false
+  "_comment": "Managed by update_icon_requests_status workflow. When enabled: requests are open. When disabled with fetch_emails_after set: emails collected once. See https://github.com/LawnchairLauncher/lawnicons-requests-dashboard/blob/main/scripts/fetch_emails.py",
+  "enabled": false,
+  "fetch_emails_after": null
 }

--- a/lawnicons-request/settings.json
+++ b/lawnicons-request/settings.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Managed by update_icon_requests_status workflow. When enabled: requests are open. When disabled with fetch_emails_after set: emails collected twice. See https://github.com/LawnchairLauncher/lawnicons-requests-dashboard/blob/main/scripts/fetch_emails.py",
+  "_comment": "Managed by update_icon_requests_status workflow. When enabled: requests are open. When disabled with fetch_emails_after set: emails collected the next day. See https://github.com/LawnchairLauncher/lawnicons-requests-dashboard/blob/main/scripts/fetch_emails.py",
   "enabled": false,
   "fetch_emails_after": null
 }


### PR DESCRIPTION
- Opens icon requests for 14 days following each major Lawnicons release, then closes them until the next release.
- Emails are collected next day after closing using `fetch_emails_after`. Trending baselines capture period start when requests open and period end after emails are collected.